### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After that, you need to select `freeform`in view controller metrics menu (image 
 
 ![Metrics](Screenshots/metrics.png)
 
-`Modaly` supports common UIViewControllers and UINavigationControllers, and the best way to discover it is download and open `Demo` XCode project:
+`Modaly` supports common UIViewControllers and UINavigationControllers, and the best way to discover it is download and open `Demo` Xcode project:
 
 ![Storyboard](Screenshots/storyboard.png)
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
